### PR TITLE
Add build-depend in debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,8 @@ Maintainer: Axel Beckert <abe@debian.org>
 Uploaders: Frank Hofmann <frank.hofmann@efho.de>
 Build-Depends: asciidoc,
                dblatex,
-               debhelper (>= 9)
+               debhelper (>= 9),
+               texlive-lang-german
 Standards-Version: 3.9.6
 Homepage: http://www.dpmb.org/
 Vcs-Git: git://github.com/dpmb/dpmb.git


### PR DESCRIPTION
need texlive-lang-german for building the pdf
